### PR TITLE
Implement support for trending links

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -264,7 +264,6 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
         setupDrawer(
             savedInstanceState,
             addSearchButton = hideTopToolbar,
-            addTrendingTagsButton = !accountManager.activeAccount!!.tabPreferences.hasTab(TRENDING_TAGS)
         )
 
         /* Fetch user info while we're doing other things. This has to be done after setting up the
@@ -289,7 +288,6 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
                     is MainTabsChangedEvent -> {
                         refreshMainDrawerItems(
                             addSearchButton = hideTopToolbar,
-                            addTrendingTagsButton = !event.newTabs.hasTab(TRENDING_TAGS)
                         )
 
                         setupTabs(false)
@@ -436,7 +434,6 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
     private fun setupDrawer(
         savedInstanceState: Bundle?,
         addSearchButton: Boolean,
-        addTrendingTagsButton: Boolean
     ) {
         val drawerOpenClickListener = View.OnClickListener { binding.mainDrawerLayout.open() }
 
@@ -497,12 +494,12 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
         })
 
         binding.mainDrawer.apply {
-            refreshMainDrawerItems(addSearchButton, addTrendingTagsButton)
+            refreshMainDrawerItems(addSearchButton)
             setSavedInstance(savedInstanceState)
         }
     }
 
-    private fun refreshMainDrawerItems(addSearchButton: Boolean, addTrendingTagsButton: Boolean) {
+    private fun refreshMainDrawerItems(addSearchButton: Boolean) {
         binding.mainDrawer.apply {
             itemAdapter.clear()
             tintStatusBar = true
@@ -619,18 +616,16 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
                 )
             }
 
-            if (addTrendingTagsButton) {
-                binding.mainDrawer.addItemsAtPosition(
-                    5,
-                    primaryDrawerItem {
-                        nameRes = R.string.title_public_trending_hashtags
-                        iconicsIcon = GoogleMaterial.Icon.gmd_trending_up
-                        onClick = {
-                            startActivityWithSlideInAnimation(TrendingActivity.getIntent(context))
-                        }
+            binding.mainDrawer.addItemsAtPosition(
+                5,
+                primaryDrawerItem {
+                    nameRes = R.string.title_public_trending
+                    iconicsIcon = GoogleMaterial.Icon.gmd_trending_up
+                    onClick = {
+                        startActivityWithSlideInAnimation(TrendingActivity.getIntent(context))
                     }
-                )
-            }
+                }
+            )
         }
 
         if (BuildConfig.DEBUG) {

--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -263,7 +263,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
 
         setupDrawer(
             savedInstanceState,
-            addSearchButton = hideTopToolbar,
+            addSearchButton = hideTopToolbar
         )
 
         /* Fetch user info while we're doing other things. This has to be done after setting up the
@@ -287,7 +287,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
                     is ProfileEditedEvent -> onFetchUserInfoSuccess(event.newProfileData)
                     is MainTabsChangedEvent -> {
                         refreshMainDrawerItems(
-                            addSearchButton = hideTopToolbar,
+                            addSearchButton = hideTopToolbar
                         )
 
                         setupTabs(false)
@@ -433,7 +433,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
 
     private fun setupDrawer(
         savedInstanceState: Bundle?,
-        addSearchButton: Boolean,
+        addSearchButton: Boolean
     ) {
         val drawerOpenClickListener = View.OnClickListener { binding.mainDrawerLayout.open() }
 

--- a/app/src/main/java/com/keylesspalace/tusky/TabData.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/TabData.kt
@@ -23,6 +23,7 @@ import com.keylesspalace.tusky.components.conversation.ConversationsFragment
 import com.keylesspalace.tusky.components.notifications.NotificationsFragment
 import com.keylesspalace.tusky.components.timeline.TimelineFragment
 import com.keylesspalace.tusky.components.timeline.viewmodel.TimelineViewModel
+import com.keylesspalace.tusky.components.trending.TrendingLinksFragment
 import com.keylesspalace.tusky.components.trending.TrendingTagsFragment
 import java.util.Objects
 
@@ -34,6 +35,7 @@ const val LOCAL = "Local"
 const val FEDERATED = "Federated"
 const val DIRECT = "Direct"
 const val TRENDING_TAGS = "TrendingTags"
+const val TRENDING_LINKS = "TrendingLinks"
 const val HASHTAG = "Hashtag"
 const val LIST = "List"
 
@@ -99,6 +101,12 @@ fun createTabDataFromId(id: String, arguments: List<String> = emptyList()): TabD
             text = R.string.title_public_trending_hashtags,
             icon = R.drawable.ic_trending_up_24px,
             fragment = { TrendingTagsFragment.newInstance() }
+        )
+        TRENDING_LINKS -> TabData(
+            id = TRENDING_LINKS,
+            text = R.string.title_public_trending_links,
+            icon =  R.drawable.ic_trending_up_24px,
+            fragment = { TrendingLinksFragment.newInstance() }
         )
         HASHTAG -> TabData(
             id = HASHTAG,

--- a/app/src/main/java/com/keylesspalace/tusky/TabData.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/TabData.kt
@@ -105,7 +105,7 @@ fun createTabDataFromId(id: String, arguments: List<String> = emptyList()): TabD
         TRENDING_LINKS -> TabData(
             id = TRENDING_LINKS,
             text = R.string.title_public_trending_links,
-            icon =  R.drawable.ic_trending_up_24px,
+            icon = R.drawable.ic_trending_up_24px,
             fragment = { TrendingLinksFragment.newInstance() }
         )
         HASHTAG -> TabData(

--- a/app/src/main/java/com/keylesspalace/tusky/TabPreferenceActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/TabPreferenceActivity.kt
@@ -378,9 +378,13 @@ class TabPreferenceActivity : BaseActivity(), Injectable, ItemInteractionListene
         if (!currentTabs.contains(directMessagesTab)) {
             addableTabs.add(directMessagesTab)
         }
-        val trendingTab = createTabDataFromId(TRENDING_TAGS)
-        if (!currentTabs.contains(trendingTab)) {
-            addableTabs.add(trendingTab)
+        val trendingTagsTab = createTabDataFromId(TRENDING_TAGS)
+        if (!currentTabs.contains(trendingTagsTab)) {
+            addableTabs.add(trendingTagsTab)
+        }
+        val trendingLinksTab = createTabDataFromId(TRENDING_LINKS)
+        if (!currentTabs.contains(trendingLinksTab)) {
+            addableTabs.add(trendingLinksTab)
         }
 
         addableTabs.add(createTabDataFromId(HASHTAG))

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingActivity.kt
@@ -15,6 +15,7 @@
 
 package com.keylesspalace.tusky.components.trending
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -66,6 +67,7 @@ class TrendingActivity : BaseActivity(), HasAndroidInjector, MenuProvider {
         onBackPressedDispatcher.addCallback(
             this,
             object : OnBackPressedCallback(true) {
+                @SuppressLint("SyntheticAccessor")
                 override fun handleOnBackPressed() {
                     if (binding.pager.currentItem != 0) binding.pager.currentItem = 0 else finish()
                 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingActivity.kt
@@ -18,16 +18,24 @@ package com.keylesspalace.tusky.components.trending
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.fragment.app.commit
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import androidx.core.view.MenuProvider
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.google.android.material.tabs.TabLayoutMediator
 import com.keylesspalace.tusky.BaseActivity
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.databinding.ActivityTrendingBinding
+import com.keylesspalace.tusky.util.reduceSwipeSensitivity
 import com.keylesspalace.tusky.util.viewBinding
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import javax.inject.Inject
 
-class TrendingActivity : BaseActivity(), HasAndroidInjector {
+class TrendingActivity : BaseActivity(), HasAndroidInjector, MenuProvider {
 
     @Inject
     lateinit var dispatchingAndroidInjector: DispatchingAndroidInjector<Any>
@@ -41,22 +49,52 @@ class TrendingActivity : BaseActivity(), HasAndroidInjector {
         setSupportActionBar(binding.includedToolbar.toolbar)
 
         supportActionBar?.run {
-            setTitle(R.string.title_public_trending_hashtags)
+            setTitle(R.string.title_public_trending)
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
         }
 
-        if (supportFragmentManager.findFragmentById(R.id.fragmentContainer) == null) {
-            supportFragmentManager.commit {
-                val fragment = TrendingTagsFragment.newInstance()
-                replace(R.id.fragmentContainer, fragment)
-            }
-        }
+        val adapter = TrendingFragmentAdapter(this)
+        binding.pager.adapter = adapter
+        binding.pager.reduceSwipeSensitivity()
+
+        TabLayoutMediator(binding.tabLayout, binding.pager) { tab, position ->
+            tab.text = adapter.title(position)
+        }.attach()
+    }
+
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.activity_trending, menu)
+    }
+
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        return super.onOptionsItemSelected(menuItem)
     }
 
     override fun androidInjector() = dispatchingAndroidInjector
 
     companion object {
         fun getIntent(context: Context) = Intent(context, TrendingActivity::class.java)
+    }
+
+}
+
+class TrendingFragmentAdapter(val activity: FragmentActivity) : FragmentStateAdapter(activity) {
+    override fun getItemCount() = 2
+
+    override fun createFragment(position: Int): Fragment {
+        return when (position) {
+            0 -> TrendingTagsFragment.newInstance()
+            1 -> TrendingLinksFragment.newInstance()
+            else -> throw IllegalStateException()
+        }
+    }
+
+    fun title(position: Int): CharSequence {
+        return when (position) {
+            0 -> activity.getString(R.string.title_tab_public_trending_hashtags)
+            1 -> activity.getString(R.string.title_tab_public_trending_links)
+            else -> throw IllegalStateException()
+        }
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingActivity.kt
@@ -76,7 +76,6 @@ class TrendingActivity : BaseActivity(), HasAndroidInjector, MenuProvider {
     companion object {
         fun getIntent(context: Context) = Intent(context, TrendingActivity::class.java)
     }
-
 }
 
 class TrendingFragmentAdapter(val activity: FragmentActivity) : FragmentStateAdapter(activity) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingActivity.kt
@@ -21,6 +21,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import androidx.activity.OnBackPressedCallback
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -61,6 +62,15 @@ class TrendingActivity : BaseActivity(), HasAndroidInjector, MenuProvider {
         TabLayoutMediator(binding.tabLayout, binding.pager) { tab, position ->
             tab.text = adapter.title(position)
         }.attach()
+
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (binding.pager.currentItem != 0) binding.pager.currentItem = 0 else finish()
+                }
+            }
+        )
     }
 
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinkViewHolder.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinkViewHolder.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2023 Tusky Contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package com.keylesspalace.tusky.components.trending
+
+import android.annotation.SuppressLint
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.widget.ImageView.ScaleType
+import android.widget.LinearLayout
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.google.android.material.shape.CornerFamily
+import com.google.android.material.shape.ShapeAppearanceModel
+import com.keylesspalace.tusky.R
+import com.keylesspalace.tusky.databinding.ItemTrendingLinkBinding
+import com.keylesspalace.tusky.entity.TrendsLink
+import com.keylesspalace.tusky.util.StatusDisplayOptions
+import com.keylesspalace.tusky.util.decodeBlurHash
+import com.keylesspalace.tusky.util.hide
+
+class TrendingLinkViewHolder(
+    private val binding: ItemTrendingLinkBinding,
+    private val onClick: (String) -> Unit
+) : RecyclerView.ViewHolder(binding.root) {
+    private var link: TrendsLink? = null
+
+    private val radius = binding.cardImage.resources.getDimensionPixelSize(R.dimen.card_radius).toFloat()
+
+    init {
+        itemView.setOnClickListener { link?.let { onClick(it.url) } }
+    }
+
+    fun bind(link: TrendsLink, statusDisplayOptions: StatusDisplayOptions) {
+        this.link = link
+
+        // TODO: This is very similar to the code in StatusBaseViewHolder.setupCard().
+        // Can a "PreviewCardView" type be created to encapsulate all this?
+        binding.cardTitle.text = link.title
+
+        val description = if (link.description.isNotBlank()) {
+            link.description
+        } else if (link.authorName.isNotBlank()) {
+            link.authorName
+        } else {
+            null
+        }
+        description?.let { binding.cardDescription.text = it } ?: binding.cardDescription.hide()
+
+        binding.cardLink.text = link.url
+
+        val cardImageShape = ShapeAppearanceModel.Builder()
+
+        if (statusDisplayOptions.mediaPreviewEnabled && !link.image.isNullOrBlank()) {
+            if (link.width > link.height) {
+                binding.statusCardView.orientation = LinearLayout.VERTICAL
+                binding.cardImage.layoutParams.height = binding.cardImage.resources.getDimensionPixelSize(R.dimen.card_image_vertical_height)
+                binding.cardImage.layoutParams.width = MATCH_PARENT
+                binding.cardInfo.layoutParams.height = MATCH_PARENT
+                binding.cardInfo.layoutParams.width = WRAP_CONTENT
+                cardImageShape.setTopLeftCorner(CornerFamily.ROUNDED, radius);
+                cardImageShape.setTopRightCorner(CornerFamily.ROUNDED, radius)
+            } else {
+                binding.statusCardView.orientation = LinearLayout.HORIZONTAL
+                binding.cardImage.layoutParams.height = MATCH_PARENT
+                binding.cardImage.layoutParams.width = binding.cardImage.resources.getDimensionPixelSize(R.dimen.card_image_horizontal_width)
+                binding.cardInfo.layoutParams.height = WRAP_CONTENT
+                binding.cardInfo.layoutParams.width = MATCH_PARENT
+                cardImageShape.setTopLeftCorner(CornerFamily.ROUNDED, radius);
+                cardImageShape.setBottomLeftCorner(CornerFamily.ROUNDED, radius)
+            }
+
+            binding.cardImage.shapeAppearanceModel = cardImageShape.build()
+            binding.cardImage.scaleType = ScaleType.CENTER_CROP
+
+            val builder = Glide.with(binding.cardImage.context)
+                .load(link.image)
+                .dontTransform()
+            if (statusDisplayOptions.useBlurhash && !link.blurhash.isNullOrBlank()) {
+                builder.placeholder(decodeBlurHash(binding.cardImage.context, link.blurhash))
+            }
+            builder.into(binding.cardImage)
+        } else if (statusDisplayOptions.useBlurhash && !link.blurhash.isNullOrBlank()) {
+            binding.statusCardView.orientation = LinearLayout.HORIZONTAL
+            binding.cardImage.layoutParams.height = MATCH_PARENT
+            binding.cardImage.layoutParams.width = binding.cardImage.resources.getDimensionPixelSize(R.dimen.card_image_horizontal_width)
+            binding.cardInfo.layoutParams.height = WRAP_CONTENT
+            binding.cardInfo.layoutParams.width = MATCH_PARENT
+
+            cardImageShape
+                .setTopLeftCorner(CornerFamily.ROUNDED, radius)
+                .setBottomLeftCorner(CornerFamily.ROUNDED, radius)
+            binding.cardImage.shapeAppearanceModel = cardImageShape.build()
+            binding.cardImage.scaleType = ScaleType.CENTER_CROP
+
+            Glide.with(binding.cardImage.context)
+                .load(decodeBlurHash(binding.cardImage.context, link.blurhash))
+                .dontTransform()
+                .into(binding.cardImage)
+        } else {
+            binding.statusCardView.orientation = LinearLayout.HORIZONTAL
+            binding.cardImage.layoutParams.height = MATCH_PARENT
+            binding.cardImage.layoutParams.width = binding.cardImage.resources.getDimensionPixelSize(R.dimen.card_image_horizontal_width)
+            binding.cardInfo.layoutParams.height = WRAP_CONTENT
+            binding.cardInfo.layoutParams.width = MATCH_PARENT
+
+            binding.cardImage.shapeAppearanceModel = ShapeAppearanceModel()
+            binding.cardImage.scaleType = ScaleType.CENTER
+
+            Glide.with(binding.cardImage.context)
+                .load(R.drawable.card_image_placeholder)
+                .into(binding.cardImage)
+        }
+
+        binding.statusCardView.clipToOutline = true
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinkViewHolder.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinkViewHolder.kt
@@ -90,9 +90,12 @@ class TrendingLinkViewHolder(
                 .load(link.image)
                 .dontTransform()
             if (statusDisplayOptions.useBlurhash && !link.blurhash.isNullOrBlank()) {
-                builder.placeholder(decodeBlurHash(binding.cardImage.context, link.blurhash))
+                builder
+                    .placeholder(decodeBlurHash(binding.cardImage.context, link.blurhash))
+                    .into(binding.cardImage)
+            } else {
+                builder.into(binding.cardImage)
             }
-            builder.into(binding.cardImage)
         } else if (statusDisplayOptions.useBlurhash && !link.blurhash.isNullOrBlank()) {
             binding.statusCardView.orientation = LinearLayout.HORIZONTAL
             binding.cardImage.layoutParams.height = MATCH_PARENT

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinkViewHolder.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinkViewHolder.kt
@@ -17,7 +17,6 @@
 
 package com.keylesspalace.tusky.components.trending
 
-import android.annotation.SuppressLint
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.ImageView.ScaleType
@@ -72,7 +71,7 @@ class TrendingLinkViewHolder(
                 binding.cardImage.layoutParams.width = MATCH_PARENT
                 binding.cardInfo.layoutParams.height = MATCH_PARENT
                 binding.cardInfo.layoutParams.width = WRAP_CONTENT
-                cardImageShape.setTopLeftCorner(CornerFamily.ROUNDED, radius);
+                cardImageShape.setTopLeftCorner(CornerFamily.ROUNDED, radius)
                 cardImageShape.setTopRightCorner(CornerFamily.ROUNDED, radius)
             } else {
                 binding.statusCardView.orientation = LinearLayout.HORIZONTAL
@@ -80,7 +79,7 @@ class TrendingLinkViewHolder(
                 binding.cardImage.layoutParams.width = binding.cardImage.resources.getDimensionPixelSize(R.dimen.card_image_horizontal_width)
                 binding.cardInfo.layoutParams.height = WRAP_CONTENT
                 binding.cardInfo.layoutParams.width = MATCH_PARENT
-                cardImageShape.setTopLeftCorner(CornerFamily.ROUNDED, radius);
+                cardImageShape.setTopLeftCorner(CornerFamily.ROUNDED, radius)
                 cardImageShape.setBottomLeftCorner(CornerFamily.ROUNDED, radius)
             }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksAdapter.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Tusky Contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package com.keylesspalace.tusky.components.trending
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil.ItemCallback
+import androidx.recyclerview.widget.ListAdapter
+import com.keylesspalace.tusky.R
+import com.keylesspalace.tusky.databinding.ItemTrendingLinkBinding
+import com.keylesspalace.tusky.entity.TrendsLink
+import com.keylesspalace.tusky.util.StatusDisplayOptions
+
+class TrendingLinksAdapter(
+    statusDisplayOptions: StatusDisplayOptions,
+    private val onViewLink: (String) -> Unit
+) : ListAdapter<TrendsLink, TrendingLinkViewHolder>(diffCallback) {
+    var statusDisplayOptions = statusDisplayOptions
+        set(value) {
+            field = value
+            notifyItemRangeChanged(0, itemCount)
+        }
+
+    init {
+        stateRestorationPolicy = StateRestorationPolicy.PREVENT_WHEN_EMPTY
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TrendingLinkViewHolder {
+        return TrendingLinkViewHolder(
+            ItemTrendingLinkBinding.inflate(LayoutInflater.from(parent.context)),
+            onViewLink
+        )
+    }
+
+    override fun onBindViewHolder(holder: TrendingLinkViewHolder, position: Int) {
+        holder.bind(getItem(position), statusDisplayOptions)
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return R.layout.item_trending_link
+    }
+
+    companion object {
+        val diffCallback = object : ItemCallback<TrendsLink>() {
+            override fun areItemsTheSame(oldItem: TrendsLink, newItem: TrendsLink): Boolean {
+                return oldItem.url == newItem.url
+            }
+
+            override fun areContentsTheSame(oldItem: TrendsLink, newItem: TrendsLink): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksFragment.kt
@@ -17,6 +17,7 @@
 
 package com.keylesspalace.tusky.components.trending
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
 import android.view.Menu
@@ -30,7 +31,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.SimpleItemAnimator
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
 import com.google.android.material.color.MaterialColors
@@ -77,7 +78,12 @@ class TrendingLinksFragment :
 
     private var talkBackWasEnabled = false
 
-    // TODO: onConfigurationChanged to show multiple columns?
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        binding.recyclerView.layoutManager = getLayoutManager(
+            requireContext().resources.getInteger(R.integer.trending_column_count)
+        )
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
@@ -161,11 +167,13 @@ class TrendingLinksFragment :
     }
 
     private fun setupRecyclerView() {
-        binding.recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.recyclerView.layoutManager = getLayoutManager(requireContext().resources.getInteger(R.integer.trending_column_count))
         binding.recyclerView.setHasFixedSize(true)
         (binding.recyclerView.itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
         binding.recyclerView.adapter = adapter
     }
+
+    private fun getLayoutManager(columnCount: Int) = GridLayoutManager(context, columnCount)
 
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
         menuInflater.inflate(R.menu.fragment_trending_links, menu)

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksFragment.kt
@@ -189,7 +189,6 @@ class TrendingLinksFragment :
     override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
         return when (menuItem.itemId) {
             R.id.action_refresh -> {
-                binding.swipeRefreshLayout.isRefreshing = true
                 refreshContent()
                 true
             }
@@ -197,7 +196,10 @@ class TrendingLinksFragment :
         }
     }
 
-    override fun refreshContent() = onRefresh()
+    override fun refreshContent() {
+        binding.swipeRefreshLayout.isRefreshing = true
+        onRefresh()
+    }
 
     override fun onRefresh() = viewModel.accept(InfallibleUiAction.Reload)
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksFragment.kt
@@ -55,6 +55,7 @@ import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import javax.inject.Inject
 
 class TrendingLinksFragment :
@@ -120,16 +121,23 @@ class TrendingLinksFragment :
                         binding.swipeRefreshLayout.isRefreshing = false
                         binding.recyclerView.hide()
                         if (adapter.itemCount != 0) {
-                            Snackbar.make(
+                            val snackbar = Snackbar.make(
                                 binding.root,
                                 it.throwable.message ?: "Error",
                                 Snackbar.LENGTH_INDEFINITE
                             )
-                                .setAction("Retry") { viewModel.accept(InfallibleUiAction.Reload) }
-                                .show()
+
+                            if (it.throwable !is HttpException || it.throwable.code() != 404) {
+                                snackbar.setAction("Retry") { viewModel.accept(InfallibleUiAction.Reload) }
+                            }
+                            snackbar.show()
                         } else {
-                            binding.messageView.setup(it.throwable) {
-                                viewModel.accept(InfallibleUiAction.Reload)
+                            if (it.throwable !is HttpException || it.throwable.code() != 404) {
+                                binding.messageView.setup(it.throwable) {
+                                    viewModel.accept(InfallibleUiAction.Reload)
+                                }
+                            } else {
+                                binding.messageView.setup(it.throwable)
                             }
                             binding.messageView.show()
                         }

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksFragment.kt
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2023 Tusky Contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package com.keylesspalace.tusky.components.trending
+
+import android.os.Bundle
+import android.util.Log
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.accessibility.AccessibilityManager
+import androidx.core.content.ContextCompat
+import androidx.core.view.MenuProvider
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.SimpleItemAnimator
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
+import com.google.android.material.color.MaterialColors
+import com.google.android.material.snackbar.Snackbar
+import com.keylesspalace.tusky.R
+import com.keylesspalace.tusky.components.trending.viewmodel.InfallibleUiAction
+import com.keylesspalace.tusky.components.trending.viewmodel.LoadState
+import com.keylesspalace.tusky.components.trending.viewmodel.TrendingLinksViewModel
+import com.keylesspalace.tusky.databinding.FragmentTrendingLinksBinding
+import com.keylesspalace.tusky.di.Injectable
+import com.keylesspalace.tusky.di.ViewModelFactory
+import com.keylesspalace.tusky.interfaces.ActionButtonActivity
+import com.keylesspalace.tusky.interfaces.RefreshableFragment
+import com.keylesspalace.tusky.interfaces.ReselectableFragment
+import com.keylesspalace.tusky.util.hide
+import com.keylesspalace.tusky.util.openLink
+import com.keylesspalace.tusky.util.show
+import com.keylesspalace.tusky.util.viewBinding
+import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class TrendingLinksFragment :
+    Fragment(R.layout.fragment_trending_links),
+    OnRefreshListener,
+    Injectable,
+    ReselectableFragment,
+    RefreshableFragment,
+    MenuProvider {
+
+    @Inject
+    lateinit var viewModelFactory: ViewModelFactory
+
+    private val viewModel: TrendingLinksViewModel by viewModels { viewModelFactory }
+
+    private val binding by viewBinding(FragmentTrendingLinksBinding::bind)
+
+    private lateinit var adapter: TrendingLinksAdapter
+
+    private var talkBackWasEnabled = false
+
+    // TODO: onConfigurationChanged to show multiple columns?
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
+
+        adapter = TrendingLinksAdapter(viewModel.statusDisplayOptions.value, ::onOpenLink)
+
+        setupSwipeRefreshLayout()
+        setupRecyclerView()
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.loadState.collectLatest {
+                when (it) {
+                    LoadState.Initial -> {
+                        viewModel.accept(InfallibleUiAction.Reload)
+                    }
+                    LoadState.Loading -> {
+                        if (!binding.swipeRefreshLayout.isRefreshing) {
+                            binding.progressBar.show()
+                        } else {
+                            binding.progressBar.hide()
+                        }
+                    }
+                    is LoadState.Success -> {
+                        adapter.submitList(it.data)
+                        binding.progressBar.hide()
+                        binding.swipeRefreshLayout.isRefreshing = false
+                        if (it.data.isEmpty()) {
+                            binding.messageView.setup(R.drawable.elephant_friend_empty,
+                                R.string.message_empty,
+                                null
+                            )
+                            binding.messageView.show()
+                        } else {
+                            binding.messageView.hide()
+                            binding.recyclerView.show()
+                        }
+                    }
+                    is LoadState.Error -> {
+                        binding.progressBar.hide()
+                        binding.swipeRefreshLayout.isRefreshing = false
+                        binding.recyclerView.hide()
+                        if (adapter.itemCount != 0) {
+                            Snackbar.make(
+                                binding.root,
+                                it.throwable.message ?: "Error",
+                                Snackbar.LENGTH_INDEFINITE
+                            )
+                                .setAction("Retry") { viewModel.accept(InfallibleUiAction.Reload) }
+                                    .show()
+                        } else {
+                            binding.messageView.setup(it.throwable) {
+                                viewModel.accept(InfallibleUiAction.Reload)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.statusDisplayOptions.collectLatest {
+                adapter.statusDisplayOptions = it
+            }
+        }
+
+        (activity as? ActionButtonActivity)?.actionButton?.hide()
+    }
+
+    private fun setupSwipeRefreshLayout() {
+        binding.swipeRefreshLayout.setOnRefreshListener(this)
+        binding.swipeRefreshLayout.setColorSchemeResources(R.color.tusky_blue)
+    }
+
+    private fun setupRecyclerView() {
+        binding.recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.recyclerView.setHasFixedSize(true)
+        (binding.recyclerView.itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
+        binding.recyclerView.adapter = adapter
+    }
+
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.fragment_trending_links, menu)
+        menu.findItem(R.id.action_refresh)?.apply {
+            icon = IconicsDrawable(requireContext(), GoogleMaterial.Icon.gmd_refresh).apply {
+                sizeDp = 20
+                colorInt =
+                    MaterialColors.getColor(binding.root, android.R.attr.textColorPrimary)
+            }
+        }
+    }
+
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        return when (menuItem.itemId) {
+            R.id.action_refresh -> {
+                binding.swipeRefreshLayout.isRefreshing = true
+                refreshContent()
+                true
+            }
+            else -> false
+        }
+    }
+
+    override fun refreshContent() = onRefresh()
+
+    override fun onRefresh() = viewModel.accept(InfallibleUiAction.Reload)
+
+    override fun onReselect() {
+        if (isAdded) {
+            binding.recyclerView.layoutManager?.scrollToPosition(0)
+            binding.recyclerView.stopScroll()
+        }
+    }
+
+    private fun onOpenLink(url: String) = requireContext().openLink(url)
+
+    override fun onResume() {
+        super.onResume()
+        val a11yManager =
+            ContextCompat.getSystemService(requireContext(), AccessibilityManager::class.java)
+
+        val wasEnabled = talkBackWasEnabled
+        talkBackWasEnabled = a11yManager?.isEnabled == true
+        Log.d(TAG, "talkback was enabled: $wasEnabled, now $talkBackWasEnabled")
+        if (talkBackWasEnabled && !wasEnabled) {
+            adapter.notifyItemRangeChanged(0, adapter.itemCount)
+        }
+    }
+
+    companion object {
+        private const val TAG = "TrendingLinksFragment"
+
+        fun newInstance() = TrendingLinksFragment()
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksFragment.kt
@@ -131,6 +131,7 @@ class TrendingLinksFragment :
                             binding.messageView.setup(it.throwable) {
                                 viewModel.accept(InfallibleUiAction.Reload)
                             }
+                            binding.messageView.show()
                         }
                     }
                 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksFragment.kt
@@ -104,7 +104,8 @@ class TrendingLinksFragment :
                         binding.progressBar.hide()
                         binding.swipeRefreshLayout.isRefreshing = false
                         if (it.data.isEmpty()) {
-                            binding.messageView.setup(R.drawable.elephant_friend_empty,
+                            binding.messageView.setup(
+                                R.drawable.elephant_friend_empty,
                                 R.string.message_empty,
                                 null
                             )
@@ -125,7 +126,7 @@ class TrendingLinksFragment :
                                 Snackbar.LENGTH_INDEFINITE
                             )
                                 .setAction("Retry") { viewModel.accept(InfallibleUiAction.Reload) }
-                                    .show()
+                                .show()
                         } else {
                             binding.messageView.setup(it.throwable) {
                                 viewModel.accept(InfallibleUiAction.Reload)

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksRepository.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingLinksRepository.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Tusky Contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package com.keylesspalace.tusky.components.trending
+
+import com.keylesspalace.tusky.network.MastodonApi
+import javax.inject.Inject
+
+class TrendingLinksRepository @Inject constructor(
+    private val api: MastodonApi
+) {
+    // TODO: Shouldn't return an emptyList by default. If there's a network error
+    // it should be returned so it can be surfaced to the user.
+    suspend fun getTrendingLinks() = api.trendingLinks()
+}

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingTagsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingTagsFragment.kt
@@ -18,11 +18,16 @@ package com.keylesspalace.tusky.components.trending
 import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.accessibility.AccessibilityManager
 import androidx.core.content.ContextCompat
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.GridLayoutManager.SpanSizeLookup
@@ -30,6 +35,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
 import at.connyduck.sparkbutton.helpers.Utils
+import com.google.android.material.color.MaterialColors
 import com.keylesspalace.tusky.BaseActivity
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.StatusListActivity
@@ -44,6 +50,10 @@ import com.keylesspalace.tusky.util.hide
 import com.keylesspalace.tusky.util.show
 import com.keylesspalace.tusky.util.viewBinding
 import com.keylesspalace.tusky.viewdata.TrendingViewData
+import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -53,7 +63,8 @@ class TrendingTagsFragment :
     OnRefreshListener,
     Injectable,
     ReselectableFragment,
-    RefreshableFragment {
+    RefreshableFragment,
+    MenuProvider {
 
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
@@ -72,6 +83,8 @@ class TrendingTagsFragment :
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
+
         setupSwipeRefreshLayout()
         setupRecyclerView()
 
@@ -96,9 +109,7 @@ class TrendingTagsFragment :
             }
         }
 
-        if (activity is ActionButtonActivity) {
-            (activity as ActionButtonActivity).actionButton?.visibility = View.GONE
-        }
+        (activity as? ActionButtonActivity)?.actionButton?.hide()
     }
 
     private fun setupSwipeRefreshLayout() {
@@ -129,6 +140,28 @@ class TrendingTagsFragment :
 
         (binding.recyclerView.itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
         binding.recyclerView.adapter = adapter
+    }
+
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.fragment_trending_tags, menu)
+        menu.findItem(R.id.action_refresh)?.apply {
+            icon = IconicsDrawable(requireContext(), GoogleMaterial.Icon.gmd_refresh).apply {
+                sizeDp = 20
+                colorInt =
+                    MaterialColors.getColor(binding.root, android.R.attr.textColorPrimary)
+            }
+        }
+    }
+
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        return when (menuItem.itemId) {
+            R.id.action_refresh -> {
+                binding.swipeRefreshLayout.isRefreshing = true
+                refreshContent()
+                true
+            }
+            else -> false
+        }
     }
 
     override fun onRefresh() {
@@ -247,7 +280,7 @@ class TrendingTagsFragment :
     }
 
     companion object {
-        private const val TAG = "TrendingFragment"
+        private const val TAG = "TrendingTagsFragment"
 
         fun newInstance() = TrendingTagsFragment()
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingTagsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingTagsFragment.kt
@@ -15,6 +15,7 @@
 
 package com.keylesspalace.tusky.components.trending
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
@@ -89,6 +90,7 @@ class TrendingTagsFragment :
         setupRecyclerView()
 
         adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
+            @SuppressLint("SyntheticAccessor")
             override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
                 if (positionStart == 0 && adapter.itemCount != itemCount) {
                     binding.recyclerView.post {

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/viewmodel/TrendingLinksViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/viewmodel/TrendingLinksViewModel.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 Tusky Contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package com.keylesspalace.tusky.components.trending.viewmodel
+
+import android.annotation.SuppressLint
+import android.content.SharedPreferences
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import at.connyduck.calladapter.networkresult.fold
+import com.keylesspalace.tusky.appstore.EventHub
+import com.keylesspalace.tusky.appstore.PreferenceChangedEvent
+import com.keylesspalace.tusky.components.trending.TrendingLinksRepository
+import com.keylesspalace.tusky.db.AccountManager
+import com.keylesspalace.tusky.entity.TrendsLink
+import com.keylesspalace.tusky.util.StatusDisplayOptions
+import com.keylesspalace.tusky.util.throttleFirst
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.ExperimentalTime
+
+sealed class UiAction
+
+sealed class InfallibleUiAction : UiAction() {
+    object Reload : InfallibleUiAction()
+}
+
+sealed class LoadState {
+    object Initial : LoadState()
+    object Loading : LoadState()
+    data class Success(val data: List<TrendsLink>) : LoadState()
+    data class Error(val throwable: Throwable) : LoadState()
+}
+
+@OptIn(ExperimentalTime::class)
+class TrendingLinksViewModel @Inject constructor(
+    private val repository: TrendingLinksRepository,
+    preferences: SharedPreferences,
+    accountManager: AccountManager,
+    private val eventHub: EventHub
+) : ViewModel() {
+    val account = accountManager.activeAccount!!
+
+    private val _loadState = MutableStateFlow<LoadState>(LoadState.Initial)
+    val loadState = _loadState.asStateFlow()
+
+    private val _statusDisplayOptions = MutableStateFlow(
+        StatusDisplayOptions.from(preferences, account)
+    )
+    val statusDisplayOptions = _statusDisplayOptions.asStateFlow()
+
+//    val data = MutableStateFlow<List<TrendsLink>>(emptyList())
+
+    private val uiAction = MutableSharedFlow<UiAction>()
+
+    val accept: (UiAction) -> Unit = { viewModelScope.launch { uiAction.emit(it) } }
+
+    init {
+        viewModelScope.launch {
+            eventHub.events
+                .filterIsInstance<PreferenceChangedEvent>()
+                .filter { StatusDisplayOptions.prefKeys.contains(it.preferenceKey) }
+                .map { _statusDisplayOptions.value.make(preferences, it.preferenceKey, account) }
+                .collect { _statusDisplayOptions.emit(it) }
+        }
+
+        viewModelScope.launch {
+            uiAction
+                .throttleFirst(THROTTLE_TIMEOUT)
+                .filterIsInstance<InfallibleUiAction.Reload>()
+                .onEach { invalidate() }
+                .collect()
+        }
+    }
+
+    private fun invalidate() = viewModelScope.launch {
+        _loadState.update { LoadState.Loading }
+        val response = repository.getTrendingLinks()
+        response.fold(
+            { list -> _loadState.update { LoadState.Success(list) } },
+            { throwable -> _loadState.update { LoadState.Error(throwable) } }
+        )
+    }
+
+    companion object {
+        @SuppressLint("unused")
+        private const val TAG = "TrendingLinksViewModel"
+        private val THROTTLE_TIMEOUT = 500.milliseconds
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/di/FragmentBuildersModule.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/di/FragmentBuildersModule.kt
@@ -32,6 +32,7 @@ import com.keylesspalace.tusky.components.search.fragments.SearchAccountsFragmen
 import com.keylesspalace.tusky.components.search.fragments.SearchHashtagsFragment
 import com.keylesspalace.tusky.components.search.fragments.SearchStatusesFragment
 import com.keylesspalace.tusky.components.timeline.TimelineFragment
+import com.keylesspalace.tusky.components.trending.TrendingLinksFragment
 import com.keylesspalace.tusky.components.trending.TrendingTagsFragment
 import com.keylesspalace.tusky.components.viewthread.ViewThreadFragment
 import com.keylesspalace.tusky.components.viewthread.edits.ViewEditsFragment
@@ -103,4 +104,7 @@ abstract class FragmentBuildersModule {
 
     @ContributesAndroidInjector
     abstract fun trendingTagsFragment(): TrendingTagsFragment
+
+    @ContributesAndroidInjector
+    abstract fun trendingLinksFragment(): TrendingLinksFragment
 }

--- a/app/src/main/java/com/keylesspalace/tusky/di/ViewModelFactory.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/di/ViewModelFactory.kt
@@ -38,6 +38,7 @@ import com.keylesspalace.tusky.components.scheduled.ScheduledStatusViewModel
 import com.keylesspalace.tusky.components.search.SearchViewModel
 import com.keylesspalace.tusky.components.timeline.viewmodel.CachedTimelineViewModel
 import com.keylesspalace.tusky.components.timeline.viewmodel.NetworkTimelineViewModel
+import com.keylesspalace.tusky.components.trending.viewmodel.TrendingLinksViewModel
 import com.keylesspalace.tusky.components.trending.viewmodel.TrendingTagsViewModel
 import com.keylesspalace.tusky.components.viewthread.ViewThreadViewModel
 import com.keylesspalace.tusky.components.viewthread.edits.ViewEditsViewModel
@@ -174,6 +175,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(TrendingTagsViewModel::class)
     internal abstract fun trendingTagsViewModel(viewModel: TrendingTagsViewModel): ViewModel
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(TrendingLinksViewModel::class)
+    internal abstract fun trendingLinksViewModel(viewModel: TrendingLinksViewModel): ViewModel
 
     @Binds
     @IntoMap

--- a/app/src/main/java/com/keylesspalace/tusky/entity/TrendsLink.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/TrendsLink.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Tusky Contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package com.keylesspalace.tusky.entity
+
+import com.google.gson.annotations.SerializedName
+
+enum class PreviewCardKind {
+    @SerializedName("link")
+    LINK,
+
+    @SerializedName("photo")
+    PHOTO,
+
+    @SerializedName("video")
+    VIDEO,
+
+    @SerializedName("rich")
+    RICH
+}
+
+/**
+ * Representation of a Mastodon [PreviewCard](https://docs.joinmastodon.org/entities/PreviewCard/)
+ */
+interface PreviewCard {
+    val url: String
+    val title: String
+    val description: String
+    val kind: PreviewCardKind
+    val authorName: String
+    val authorUrl: String
+    val providerName: String
+    val providerUrl: String
+    val html: String
+    val width: Int
+    val height: Int
+    val image: String?
+    val embedUrl: String
+    val blurhash: String?
+}
+
+data class LinkHistory(
+    val day: String,
+    val accounts: Int,
+    val uses: Int
+)
+
+data class TrendsLink(
+    override val url: String,
+    override val title: String,
+    override val description: String,
+    @SerializedName("type") override val kind: PreviewCardKind,
+    @SerializedName("author_name") override val authorName: String,
+    @SerializedName("author_url") override val authorUrl: String,
+    @SerializedName("provider_name") override val providerName: String,
+    @SerializedName("provider_url") override val providerUrl: String,
+    override val html: String,
+    override val width: Int,
+    override val height: Int,
+    override val image: String? = null,
+    @SerializedName("embed_url") override val embedUrl: String,
+    override val blurhash: String? = null,
+    val history: List<LinkHistory>
+) : PreviewCard

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -45,6 +45,7 @@ import com.keylesspalace.tusky.entity.StatusEdit
 import com.keylesspalace.tusky.entity.StatusSource
 import com.keylesspalace.tusky.entity.TimelineAccount
 import com.keylesspalace.tusky.entity.TrendingTag
+import com.keylesspalace.tusky.entity.TrendsLink
 import io.reactivex.rxjava3.core.Single
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
@@ -783,4 +784,7 @@ interface MastodonApi {
 
     @GET("api/v1/trends/tags")
     suspend fun trendingTags(): NetworkResult<List<TrendingTag>>
+
+    @GET("api/v1/trends/links")
+    suspend fun trendingLinks(): NetworkResult<List<TrendsLink>>
 }

--- a/app/src/main/java/com/keylesspalace/tusky/util/ThrowableExtensions.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ThrowableExtensions.kt
@@ -31,12 +31,19 @@ fun Throwable.getServerErrorMessage(): String? {
 /** @return A drawable resource to accompany the error message for this throwable */
 fun Throwable.getDrawableRes(): Int = when (this) {
     is IOException -> R.drawable.elephant_offline
-    is HttpException -> R.drawable.elephant_offline
+    is HttpException -> {
+        if (this.code() == 404) {
+            R.drawable.elephant_friend_empty
+        } else {
+            R.drawable.elephant_offline
+        }
+    }
     else -> R.drawable.elephant_error
 }
 
 /** @return A string error message for this throwable */
 fun Throwable.getErrorString(context: Context): String = getServerErrorMessage() ?: when (this) {
     is IOException -> context.getString(R.string.error_network)
+    is HttpException -> if (this.code() == 404) context.getString(R.string.error_404_not_found) else context.getString(R.string.error_generic)
     else -> context.getString(R.string.error_generic)
 }

--- a/app/src/main/res/layout/activity_trending.xml
+++ b/app/src/main/res/layout/activity_trending.xml
@@ -1,17 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context="com.keylesspalace.tusky.components.trending.TrendingActivity">
 
-    <include
-        android:id="@+id/includedToolbar"
-        layout="@layout/toolbar_basic" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:elevation="@dimen/actionbar_elevation"
+        app:elevationOverlayEnabled="false">
 
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/fragmentContainer"
+        <include
+            android:id="@+id/includedToolbar"
+            layout="@layout/toolbar_basic" />
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tab_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:tabGravity="fill"
+            app:tabMode="fixed" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />

--- a/app/src/main/res/layout/fragment_trending_links.xml
+++ b/app/src/main/res/layout/fragment_trending_links.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground">
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefreshLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+            <com.keylesspalace.tusky.view.BackgroundMessageView
+                android:id="@+id/messageView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:visibility="gone"
+                tools:visibility="visible" />
+        </FrameLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_trending_links.xml
+++ b/app/src/main/res/layout/fragment_trending_links.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="?android:attr/colorBackground">
+    android:layout_height="match_parent">
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefreshLayout"

--- a/app/src/main/res/layout/fragment_trending_tags.xml
+++ b/app/src/main/res/layout/fragment_trending_tags.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="?android:attr/colorBackground">
+    android:layout_height="match_parent">
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefreshLayout"

--- a/app/src/main/res/layout/item_trending_link.xml
+++ b/app/src/main/res/layout/item_trending_link.xml
@@ -19,6 +19,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
     android:paddingStart="14dp"
     android:paddingEnd="14dp">
 
@@ -64,7 +65,8 @@
                 android:fontFamily="sans-serif-medium"
                 android:lines="1"
                 android:textColor="?android:textColorSecondary"
-                android:textSize="?attr/status_text_medium" />
+                android:textSize="?attr/status_text_medium"
+                tools:ignore="SelectableText" />
 
             <TextView
                 android:id="@+id/card_description"
@@ -75,7 +77,8 @@
                 android:lineSpacingMultiplier="1.1"
                 android:maxLines="2"
                 android:textColor="?android:textColorSecondary"
-                android:textSize="?attr/status_text_medium" />
+                android:textSize="?attr/status_text_medium"
+                tools:ignore="SelectableText" />
 
             <TextView
                 android:id="@+id/card_link"
@@ -84,7 +87,8 @@
                 android:ellipsize="end"
                 android:lines="1"
                 android:textColor="?android:textColorTertiary"
-                android:textSize="?attr/status_text_medium" />
+                android:textSize="?attr/status_text_medium"
+                tools:ignore="SelectableText" />
         </LinearLayout>
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_trending_link.xml
+++ b/app/src/main/res/layout/item_trending_link.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2023 Tusky Contributors
+  ~
+  ~ This file is a part of Tusky.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Tusky; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingStart="14dp"
+    android:paddingEnd="14dp">
+
+    <LinearLayout
+        android:id="@+id/status_card_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/card_frame"
+        android:clipChildren="true"
+        android:foreground="?attr/selectableItemBackground"
+        android:minHeight="80dp"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/card_image"
+            android:layout_width="match_parent"
+            android:layout_height="300dp"
+            android:layout_margin="1dp"
+            android:background="?attr/colorBackgroundAccent"
+            android:importantForAccessibility="no"
+            android:scaleType="center" />
+
+        <LinearLayout
+            android:id="@+id/card_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingLeft="6dp"
+            android:paddingTop="6dp"
+            android:paddingRight="6dp"
+            android:paddingBottom="6dp">
+
+            <TextView
+                android:id="@+id/card_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:ellipsize="end"
+                android:fontFamily="sans-serif-medium"
+                android:lines="1"
+                android:textColor="?android:textColorSecondary"
+                android:textSize="?attr/status_text_medium" />
+
+            <TextView
+                android:id="@+id/card_description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:ellipsize="end"
+                android:lineSpacingMultiplier="1.1"
+                android:maxLines="2"
+                android:textColor="?android:textColorSecondary"
+                android:textSize="?attr/status_text_medium" />
+
+            <TextView
+                android:id="@+id/card_link"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:lines="1"
+                android:textColor="?android:textColorTertiary"
+                android:textSize="?attr/status_text_medium" />
+        </LinearLayout>
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/activity_trending.xml
+++ b/app/src/main/res/menu/activity_trending.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+</menu>

--- a/app/src/main/res/menu/fragment_trending_links.xml
+++ b/app/src/main/res/menu/fragment_trending_links.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_refresh"
+        android:title="@string/action_refresh"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/menu/fragment_trending_tags.xml
+++ b/app/src/main/res/menu/fragment_trending_tags.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_refresh"
+        android:title="@string/action_refresh"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="error_could_not_load_login_page">Could not load the login page.</string>
     <string name="error_compose_character_limit">The post is too long!</string>
     <string name="error_multimedia_size_limit">Video and audio files cannot exceed %s MB in size.</string>
+    <string name="error_404_not_found">Your server does not support this feature</string>
 
     <string name="error_image_edit_failed">The image could not be edited.</string>
     <string name="error_media_upload_type">That type of file cannot be uploaded.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,7 +51,11 @@
     <string name="title_home">Home</string>
     <string name="title_notifications">Notifications</string>
     <string name="title_public_local">Local</string>
-    <string name="title_public_trending_hashtags">Trending hashtags</string>
+    <string name="title_public_trending">Trending</string>
+    <string name="title_public_trending_hashtags">Trending Hashtags</string>
+    <string name="title_public_trending_links">Trending Links</string>
+    <string name="title_tab_public_trending_hashtags">Hashtags</string>
+    <string name="title_tab_public_trending_links">Links</string>
     <string name="title_public_federated">Federated</string>
     <string name="title_direct_messages">Direct messages</string>
     <string name="title_tab_preferences">Tabs</string>


### PR DESCRIPTION
Expand the "trending" support to include trending links.

Main changes:

- `TrendingActivity` can now host multiple trending fragments in a viewpager, and swipe between them
- Implement a `TrendingLinks` suite (`Fragment`, `ViewModel`, `Adapter`, `Repository`, etc to get and display the data
- Always show "Trending" on the left-nav menu
- Support adding trending links as a dedicated tab